### PR TITLE
Changed Kiev to Kyiv

### DIFF
--- a/data.json
+++ b/data.json
@@ -23,7 +23,7 @@
 			"url": "http://yglf.com.ua/",
 			"name": "YGLF",
 			"date": "2018-05-24",
-			"city": "Kiev",
+			"city": "Kyiv",
 			"country": "ua"
 		},
 		{


### PR DESCRIPTION
This updates city name transliteration to from Ukrainian.  
From 1995 it is standard transliteration http://www.uazone.net/Kiev_Kyiv.html