### PR TITLE
Redirect old URLs pointing to `projects.verou.me/contrast-ratio`

### DIFF
--- a/contrast-ratio/index.html
+++ b/contrast-ratio/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 
 <head>
-	<meta http-equiv="refresh" content="0;url=https://contrast-ratio.com">
+	<link rel="canonical" href="https://contrast-ratio.com" />
+	<meta http-equiv="refresh" content="0;url=https://contrast-ratio.com" />
 	<title>Redirecting...</title>
 </head>
 

--- a/contrast-ratio/index.html
+++ b/contrast-ratio/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta http-equiv="refresh" content="0;url=https://contrast-ratio.com">
+	<title>Redirecting...</title>
+</head>
+
+<body>
+	<p>If you are not redirected, <a href="https://contrast-ratio.com">click here</a>.</p>
+</body>
+
+</html>


### PR DESCRIPTION
Since there is no longer a `contrast-ratio` repo under your user and `projects.verou.me` points to `leaverou.github.io`, the only way (at least, I couldn't find any other) to redirect URLs is to create a `contrast-ratio` folder with an `index.html` and rely on the browser's meta refresh.

To improve SEO a bit, I used a canonical link.

Closes https://github.com/LeaVerou/lea.verou.me/issues/93